### PR TITLE
Handle explicit line breaks in layout

### DIFF
--- a/lib/engine/elements/layout_blocks/line_break_inline_element.dart
+++ b/lib/engine/elements/layout_blocks/line_break_inline_element.dart
@@ -1,0 +1,15 @@
+import 'dart:ui';
+
+import 'inline_element.dart';
+
+class LineBreakInlineElement extends InlineElement {
+  @override
+  void performLayout(double maxWidth) {
+    width = 0;
+    height = 0;
+    baseline = 0;
+  }
+
+  @override
+  void paint(Canvas canvas, Offset offset) {}
+}


### PR DESCRIPTION
## Summary
- Split text using regex to produce LineBreakInlineElement for `\n` and individual TextInlineElements for whitespace
- Add `LineBreakInlineElement` with zero size
- Commit line when encountering `LineBreakInlineElement`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a10b288832e927a21a1ab22415d